### PR TITLE
Clarify that members are natural persons

### DIFF
--- a/bylaws/2-cf-membership.md
+++ b/bylaws/2-cf-membership.md
@@ -6,11 +6,19 @@ weight: 2
 
 The Commonhaus Foundation (CF) is a membership organization. The following section outlines the different types of membership and the process for becoming a member.
 
+- [Rights and requirements](#rights-and-requirements)
 - [Project Leaders and Code Owners](#project-leaders-and-code-owners)
 - [General Members](#general-members)
 - [Membership Dues and Renewal](#membership-dues-and-renewal)
 - [Inactive or Retired Members](#inactive-or-retired-members)
 - [Suspension and Revocation of Membership](#suspension-and-revocation-of-membership)
+
+## Rights and requirements
+
+Commonhaus Foundation members are natural persons, and join as individuals.
+This excludes in particular legal entities, which are exclusively represented as part of the [advisory board][].
+
+Each member has a voice, can raise issues (for all members, for all project leads, for the council), and is entitled to a vote in member decisions (which includes both elections and referendums).
 
 ## Project Leaders and Code Owners
 
@@ -59,6 +67,7 @@ These situations will be recorded as violations of the [Code of Conduct][coc] an
 
 The decision to revoke or suspend membership is made by a supermajority vote of the CFC. The member in question will be notified of the decision and the reasons for it.
 
+[advisory board]: ./4-cf-advisory-board.md
 [cfc]: ./3-cf-council.md
 [coc]: ../policies/code-of-conduct.md
 [coc-reports]: ../policies/code-of-conduct.md#handling-reports-and-escalations

--- a/bylaws/4-cf-advisory-board.md
+++ b/bylaws/4-cf-advisory-board.md
@@ -6,7 +6,9 @@ weight: 4
 
 The Commonhaus Foundation (CF) Advisory Board comprises representatives from organizations and companies that support the CF. It acts as a bridge between the CF and the broader tech industry, providing diverse insights and strategic guidance to inform CF Council (CFC) decisions.
 
-The Advisory Board does not have decision-making authority but plays a crucial role in shaping the foundation's direction through advice and industry perspectives. The structure is designed to ensure robust representation and dialogue:
+The Advisory Board does not have decision-making authority. Members or employees of participating organizations and companies may be [members of the CF][membership], but must vote in their own name, free of any pressure from their organization or company.
+
+However, the Advisory Board plays a crucial role in shaping the foundation's direction through advice and industry perspectives. The structure is designed to ensure robust representation and dialogue:
 
 - **Representation**: Each Advisory Board member organization may appoint up to two representatives. This dual representation maximizes the likelihood of attendance and ensures a breadth of perspectives, mirroring the Gnome Foundation's approach to encourage diverse viewpoints from vendors.
 
@@ -20,4 +22,5 @@ The Advisory Board does not have decision-making authority but plays a crucial r
 
 An up-to-date list of Advisory Board representatives will be maintained in the `advisory-board` [CONTACTS.yaml][] attribute.
 
+[membership]: ./2-cf-membership.md
 [CONTACTS.yaml]: https://github.com/commonhaus/foundation-draft/blob/main/CONTACTS.yaml


### PR DESCRIPTION
That wasn't obvious to me, at least. Upon reading the membership section I didn't find any explicit mention of it.

I *think* "natural persons" (yes, plural) is correct in legal linguo, but I'll let native speakers confirm.

I suppose we could add " without restriction of citizenship or origin to the extent allowed by U.S. law.", but I guess that goes without saying.