### PR TITLE
Revise/clarify conflict of interest

### DIFF
--- a/policies/conflict-of-interest.md
+++ b/policies/conflict-of-interest.md
@@ -3,7 +3,7 @@ status: draft
 ---
 # Conflict of Interest Policy
 
-This document establishes policies for identifying, disclosing, and managing conflicts of interest within the CF.
+This document outlines the Conflict of Interest Policy for the Commonhaus Foundation (CF), setting the framework for identifying, disclosing, and managing potential conflicts of interest to protect the Foundation’s interest when it is contemplating entering a [transaction](#definitions) that might benefit the private interest of a [covered individual](#scope-of-application).
 
 This policy applies to all individuals with decision-making authority within the CF, including CF Council (CFC) members and officers, and extends to project leaders and members when their interests may influence Foundation activities.
 
@@ -20,57 +20,79 @@ This policy applies to all individuals with decision-making authority within the
 - [Procedures for Determining Compensation](#procedures-for-determining-compensation)
 - [Review of Policy](#review-of-policy)
 
-## Definition of Conflict of Interest
+## Scope of Application
 
-A conflict of interest occurs when an individual's personal, professional, or financial interests could potentially interfere with or influence their decisions or actions on behalf of the CF.
+This policy applies to all individuals within the CF who possess decision-making authority. This includes:
+
+- Members of the Commonhaus Foundation Council (CFC)
+- Members of the Extended Governance Committee (EGC)
+- Appointed officers of the CF
+- Project representatives
+- General members, when their personal or professional interests could potentially influence the decisions or activities of the Foundation.
+- Key employees[^1]
+
+[^1]: If and when the CF employs full-time staff, a key employee is an employee whose total annual compensation (including benefits) from the foundation and its affiliates is more than $150,000 and who (a) has responsibilities or influence over the foundation similar to that of officers or Councilors; or (b) manages a program that represents 10% or more of the activities, assets, income, or expenses of the foundation; or (c) has or shares authority to control 10% or more of the foundation capital expenditures, operating budget, or compensation for employees.
+
+## Definitions
+
+**Interest** means any commitment, investment, relationship, obligation, or involvement, financial or otherwise, direct or indirect, that may influence a person’s judgment, including receipt of compensation from the CF, a sale, loan, or exchange transaction with the CF.
+
+A **conflict of interest** arises when a covered individual’s personal interest in a transaction might prevent them from acting impartially in the best interest of the CF.
+
+**Transaction** means any transaction, agreement, or arrangement between a [covered individual](#scope-of-application) and the CF, or between the CF and any third party where a covered individual has an interest in the transaction or any party to it. Transaction does not include compensation arrangements between the Foundation and a director, officer, or other covered individual that are covered by other policies.
 
 ### Examples
 
-- Financial interest in any entity with which CF transacts.
-- Board membership, employment, or volunteer work with such an entity.
-- Personal gifts or loans from any entity dealing with CF.
-- Relationship with another nonprofit competing for the same resources.
-- Personal or business relationships affecting CF decisions.
+- The Foundation purchases products manufactured by the spouse of the Executive Director.
+- The Foundation engages a firm for financial advice and the Financial Director serves as a director of that firm.
+- The Foundation purchases services from a company owned by a director's sibling
 
-## Disclosing Potential Conflicts of Interest
-
-### Immediate Disclosure
-
-All individuals must disclose any potential conflict of interest as soon as it is recognized. This disclosure should be made to the CFC or a designated point of contact.
-
-### Annual Disclosure
-
-Each member of the CFC and officers must provide an annual statement declaring any known potential conflicts of interest.
-
-## Managing Conflicts
-
-Upon the disclosure of a potential conflict, the individual involved must abstain from participating in discussions or decision-making processes related to the matter. The CFC will review the situation and determine the appropriate course of action.
-
-## Transparency and Documentation
-
-All discussions and decisions related to conflicts of interest must be documented and included in the minutes of the CFC meetings.
-
-## Prohibited Acts
-
-The CF will not engage in transactions where there is a direct conflict of interest with a CFC member, officer, or key person, unless it is in the best interest of the CF and has been thoroughly vetted and approved by the CFC.
-
-## Guidelines for Gifts and Hospitality
-
-Members should not accept gifts, favors, or hospitality that might appear to influence their decision-making or actions on behalf of the CF.
-
-## Training and Compliance
-
-Members will be provided with information and training to understand and adhere to this policy. Failure to comply may result in corrective action, including potential removal from their position within the CF.
-
-## Procedures for Determining Compensation
+### Procedures for Determining Compensation
 
 When hiring staff or paying for contract work, the CFC will reference industry standards to ensure compensation is fair and justified. The process will be transparent and fully documented.
 
 All individuals will abstain from discussions or votes concerning their own compensation or that of those closely associated with them.
 
+## Disclosing Potential Conflicts of Interest
+
+Each covered individual shall disclose to the CFC all material facts regarding his or her interest in the transaction, promptly upon learning of the proposed transaction.
+
+It is important to note that the existence of a conflict does not mean the transaction cannot occur, but the Foundation must act to address the conflict in order to ensure that the transaction is in the best interests of the Foundation.
+
+## Determining Whether a Conflict of Interest Exists
+
+Upon the disclosure of a potential conflict, the CFC shall determine if a conflict of interest exists.
+
+The covered individual(s) and any other interested person(s) involved with the transaction shall not be present during the CFC's discussion or determination of whether a conflict of interest exists, except as provided in [below](#review-by-the-cfc).
+
+### Review by the CFC
+
+The CFC may ask questions of and receive presentation(s) from the covered individual(s) and any other interested person(s), but shall deliberate and vote on the transaction in their absence. 
+
+The CFC shall ascertain that all material facts regarding the transaction and the covered individual’s conflict of interest have been disclosed to the CFC and shall compile appropriate data, such as comparability studies, to determine fair market value for the transaction.
+
+After exercising due diligence, which may include investigating alternatives that present no conflict, the CFC shall determine whether the transaction is in the Foundation’s best interest, for its own benefit, and whether it is fair and reasonable to the Foundation; the majority of disinterested members of the CFC then in office may approve the transaction.
+
+### Records of Review
+
+The minutes of any meeting of the CFC pursuant to this policy shall contain the name of each covered individual who disclosed or was otherwise determined to have an interest in a transaction; the nature of the interest and whether it was determined to constitute a conflict of interest; any alternative transactions considered; the members of the CFC who were present during the deliberations on the transaction, those who voted on it, and to what extent interested persons were excluded from the deliberations; any comparability data or other information obtained and relied upon by the CFC and how the information was obtained; and the result of the vote, including, if applicable, the terms of the transaction that was approved and the date it was approved.
+
+#### Annual Disclosure and Compliance
+
+- CFC members (Councilors), EGC Members, and key employees (if any) must annually affirm that they have received, read, understood this policy, and that they agree to comply with it. They must disclose any financial interests and family relationships that could give rise to conflicts of interest.
+- General CF members must affirm that they have received, read, understood this policy, and that they agree to comply with it, when applicable.
+
+## Violations
+
+If the CFC has reasonable cause to believe that a covered individual of the Foundation has failed to disclose actual or possible conflicts of interest, including those arising from a transaction with a related interested person, it shall inform such covered individual of the basis for this belief and afford the covered individual an opportunity to explain the alleged failure to disclose. 
+
+If, after hearing the covered individual’s response and making further investigation as warranted by the circumstances, the CFC determines that the covered individual has failed to disclose an actual or possible conflict of interest, the CFC shall take appropriate disciplinary and corrective action.
+
 ## Review of Policy
 
-This policy will be reviewed periodically to ensure it remains relevant and effective. Amendments or changes to this policy will follow the [amendment process][].
+This policy will be reviewed periodically to ensure it remains relevant and effective.
+
+Amendments or changes to this policy will follow the [amendment process][].
 
 For questions or clarifications on this policy, please contact the [`legal` mailing list][CONTACTS.yaml].
 

--- a/policies/conflict-of-interest.md
+++ b/policies/conflict-of-interest.md
@@ -3,21 +3,17 @@ status: draft
 ---
 # Conflict of Interest Policy
 
-This document outlines the Conflict of Interest Policy for the Commonhaus Foundation (CF), setting the framework for identifying, disclosing, and managing potential conflicts of interest to protect the Foundation’s interest when it is contemplating entering a [transaction](#definitions) that might benefit the private interest of a [covered individual](#scope-of-application).
+This document outlines the Conflict of Interest Policy for the Commonhaus Foundation (CF), setting the framework for identifying, disclosing, and managing potential conflicts of interest to protect the Foundation’s interest when it is contemplating entering a [transaction](#definitions) that might benefit the personal or professional interests of a [covered individual](#scope-of-application).
 
-This policy applies to all individuals with decision-making authority within the CF, including CF Council (CFC) members and officers, and extends to project leaders and members when their interests may influence Foundation activities.
-
-- [Definition of Conflict of Interest](#definition-of-conflict-of-interest)
+- [Scope of Application](#scope-of-application)
+- [Definitions](#definitions)
     - [Examples](#examples)
+    - [Procedures for Determining Compensation](#procedures-for-determining-compensation)
 - [Disclosing Potential Conflicts of Interest](#disclosing-potential-conflicts-of-interest)
-    - [Immediate Disclosure](#immediate-disclosure)
-    - [Annual Disclosure](#annual-disclosure)
-- [Managing Conflicts](#managing-conflicts)
-- [Transparency and Documentation](#transparency-and-documentation)
-- [Prohibited Acts](#prohibited-acts)
-- [Guidelines for Gifts and Hospitality](#guidelines-for-gifts-and-hospitality)
-- [Training and Compliance](#training-and-compliance)
-- [Procedures for Determining Compensation](#procedures-for-determining-compensation)
+- [Determining Whether a Conflict of Interest Exists](#determining-whether-a-conflict-of-interest-exists)
+    - [Review by the CFC](#review-by-the-cfc)
+    - [Records of Review](#records-of-review)
+- [Violations](#violations)
 - [Review of Policy](#review-of-policy)
 
 ## Scope of Application
@@ -31,7 +27,7 @@ This policy applies to all individuals within the CF who possess decision-making
 - General members, when their personal or professional interests could potentially influence the decisions or activities of the Foundation.
 - Key employees[^1]
 
-[^1]: If and when the CF employs full-time staff, a key employee is an employee whose total annual compensation (including benefits) from the foundation and its affiliates is more than $150,000 and who (a) has responsibilities or influence over the foundation similar to that of officers or Councilors; or (b) manages a program that represents 10% or more of the activities, assets, income, or expenses of the foundation; or (c) has or shares authority to control 10% or more of the foundation capital expenditures, operating budget, or compensation for employees.
+[^1]: If and when the CF employs full-time staff, a key employee is an employee who (a) has responsibilities or influence over the foundation similar to that of officers or Councilors; or (b) manages a program that represents 10% or more of the activities, assets, income, or expenses of the foundation; or (c) has or shares authority to control 10% or more of the foundation capital expenditures, operating budget, or compensation for employees.
 
 ## Definitions
 
@@ -67,7 +63,7 @@ The covered individual(s) and any other interested person(s) involved with the t
 
 ### Review by the CFC
 
-The CFC may ask questions of and receive presentation(s) from the covered individual(s) and any other interested person(s), but shall deliberate and vote on the transaction in their absence. 
+The CFC may ask questions of and receive presentation(s) from the covered individual(s) and any other interested person(s), but shall deliberate and vote on the transaction in their absence.
 
 The CFC shall ascertain that all material facts regarding the transaction and the covered individual’s conflict of interest have been disclosed to the CFC and shall compile appropriate data, such as comparability studies, to determine fair market value for the transaction.
 
@@ -84,7 +80,7 @@ The minutes of any meeting of the CFC pursuant to this policy shall contain the 
 
 ## Violations
 
-If the CFC has reasonable cause to believe that a covered individual of the Foundation has failed to disclose actual or possible conflicts of interest, including those arising from a transaction with a related interested person, it shall inform such covered individual of the basis for this belief and afford the covered individual an opportunity to explain the alleged failure to disclose. 
+If the CFC has reasonable cause to believe that a covered individual of the Foundation has failed to disclose actual or possible conflicts of interest, including those arising from a transaction with a related interested person, it shall inform such covered individual of the basis for this belief and afford the covered individual an opportunity to explain the alleged failure to disclose.
 
 If, after hearing the covered individual’s response and making further investigation as warranted by the circumstances, the CFC determines that the covered individual has failed to disclose an actual or possible conflict of interest, the CFC shall take appropriate disciplinary and corrective action.
 


### PR DESCRIPTION
Follow-on to #58 

Reframe Conflict of Interest to more clearly resemble that used by the Gnome Software foundation (https://wiki.gnome.org/Foundation/ConflictOfInterest).