### PR TITLE
IP Policy clarification/revision

### DIFF
--- a/policies/ip-policy.md
+++ b/policies/ip-policy.md
@@ -3,50 +3,76 @@ status: draft
 ---
 # Intellectual Property Policy
 
-This document outlines our policies on intellectual property (IP) to guide contributors and safeguard the interests of our projects and community.
+The Commonhaus Foundation (CF) supports individual projects (each, a “Project” and together, the “Projects”).
+
+All new inbound code contributions to individual Projects are made pursuant to the license applicable to each such Project (with respect to each Project, the “Project Code License”).
 
 ## License Selection and Usage
 
-CF projects can use any [open-source license approved by the Open Source Initiative](https://opensource.org/licenses/) (OSI). The CF is most familiar with the following four licenses, which can simplify the review process:
+> [!TIP]
+> CF supports a wide range of open-source licenses to ensure projects can choose what's best for them. We’ll check these licenses, including for any software they rely on, to make sure everything works together without legal issues.
+
+CF projects can use any [open-source license approved by the Open Source Initiative](https://opensource.org/licenses/) (OSI).
+
+The CF will review Project Code Licenses and the licenses of its dependencies to ensure that all components of the project are compatible under the chosen license and do not introduce legal conflicts or restrictions that could affect the Project's or Foundation's operation.
+
+The CF is most familiar with the following four licenses, which can simplify the review process:
 
 - [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 - [The MIT License][MIT]
 - [The 2-Clause BSD License](https://opensource.org/license/bsd-2-clause/)
 - [The 3-Clause BSD License](https://opensource.org/license/bsd-3-clause/)
 
-Selection of other OSI-approved licenses is permitted but may require additional review by the [Commonhaus Foundation Council][cfc] (CFC).
+### Documentation and Media Files
+
+> [!TIP]
+> Projects can pick appropriate licenses, including non-commercial Creative Commons licenses, for their non-code content like documentation and images.
+
+A CF Project can define a "Project Documentation License" to cover all documentation, image, and audiovisual files (e.g., .txt., .rtf, .doc, .pdf, .jpg, .tif, .mp3, .wav, and some .html files) (including without limitation code that is intended as sample code if included in a documentation file).
+The Project Documentation License can be any OSI-approved license or a non-commercial Creative Commons license (like [CC BY 4.0](http://creativecommons.org/licenses/by/4.0/)).
 
 ## Contributions
 
-Code contributions should comply with the project's chosen license.
+> [!TIP]
+> All code contributions must align with the project’s license and come with a promise (DCO) from contributors that they have the right to contribute under these terms.
 
-Contributions are validated through a [Developer Certificate of Origin][DCO] (DCO) or a Contributor License Agreement (CLA), as determined by the project.
+All new code contributions to any Project shall be made under the Project Code License accompanied by a Developers Certificate of Origin (DCO, available at <http://developercertificate.org/>), which will bind the individual contributor and, if applicable, their employer to the Project Code License.
 
-### Documentation and Media Files
+The technical governing body of each Project may provide for additional requirements with respect to contributions. For example, a Project may require that new code contributions to a Project be accompanied by a signed Contributor License Agreement (CLA).
 
-Projects should choose an appropriate license for documentation and media files, such as [CC BY 4.0][] or the project's primary license.
+### Developers Certificate of Origin (DCO) or Contributor License Agreement (CLA)?
 
-All contributions must be clearly labeled with license information.
+The DCO and CLA differ in their approach to intellectual property rights.
 
-## Collaborations and External Projects
+- A DCO is a lightweight method for contributors to certify they have the rights to submit their work, typically requiring a signed statement within the commit message.
+- A CLA is a more formal agreement where contributors grant the project rights to use their contributions, often including a detailed legal framework around contributions.
 
-When collaborating with external open-source projects ("Upstream Projects"):
-
-- Comply with the Upstream Project's licensing requirements.
-- Prioritize compatibility
-- Seek alternative license approvals from the CFC when necessary.
+CLAs can provide projects with more legal protection, while DCOs offer a simpler, less legally invasive way for developers to contribute.
 
 ## Intellectual Property Rights
 
-CF membership does not grant or transfer intellectual property rights unless explicitly stated by this policy or a Project's license.
+> [!TIP]
+> Joining CF doesn’t grant us any rights to your IP beyond what’s needed for project contributions. Your IP remains yours.
+
+Except for (a) each member’s commitment to be bound by this Policy, the applicable Project Code License(s), and the applicable Project Documentation License(s), in each case with respect to its or its employees’ authorized contributions to any Project; and (b) any applicable contributor license agreement, if any, no license is granted by the member to its intellectual property, and none shall be implied by general membership in the Commonhaus Foundation.
 
 ## Implementing the IP Policy
 
 Project leaders should ensure compliance with this policy and provide clear guidance to contributors.
 
-- Use the [standard website footer][] for member project websites,
+- Use the [standard website footer][] for member project websites to reference this and other CF Policies,
 - Ensure that contribution guidelines are updated and accessible, and
 - (optionally) Maintain accurate copyright statements.
+
+## Collaborations and External Projects
+
+> [!TIP]
+> Always check and follow the license rules of any external open-source projects we interact with.
+> If an upstream project uses a non-OSI license, the [CF Council (CFC)][cfc] can approve exceptions if needed.
+
+Engaging with external open-source projects requires awareness and respect for their licensing terms to ensure our contributions are legally compatible. This ensures our projects can seamlessly integrate or collaborate with these external projects without infringing on their or our license terms.
+
+When collaborating with external open-source projects ("Upstream Projects") conform to all license requirements of the Upstream Projects, including dependencies, leveraged by the Project. If an alternative inbound or outbound license is required for compliance with the license for an Upstream Project or is otherwise required to achieve the Commonhaus Foundation’s, or an individual Project’s, objectives, the CFC may approve the use of an alternative license for inbound or outbound contributions on an exception basis.
 
 ### Copyright Statements
 
@@ -65,9 +91,9 @@ Updating the year after the file is created is unnecessary.
 
 ## Obtaining an Exemption
 
-If the [IP Policy][] doesn't cater to your project's needs, request special permission from the CFC.
+If this IP Policy doesn't cater to your project's needs, request special permission from the CFC.
 
-[Steps to request an exemption TBD]
+To request an exemption, please begin by contacting the CFC through the [`council` mailing list][CONTACTS.yaml]. Further instructions will be provided based on the specifics of your request.
 
 ## Review of Policy
 
@@ -75,10 +101,7 @@ This policy will be reviewed periodically to ensure it remains relevant and effe
 
 For questions or clarifications on this policy, please contact the [`legal` mailing list][CONTACTS.yaml].
 
-[CC BY 4.0]: http://creativecommons.org/licenses/by/4.0/ "Creative Commons Attribution 4.0 International License (CC BY 4.0)"
 [CONTACTS.yaml]: https://github.com/commonhaus/foundation-draft/blob/main/CONTACTS.yaml
-[DCO]: http://developercertificate.org/
-[IP Policy]: ../policies/ip-policy.md
 [MIT]: https://opensource.org/license/mit/ "The MIT License"
 [amendment process]: ../bylaws/8-amendments.md
 [cfc]: ../bylaws/3-cf-council.md "CF Council"

--- a/policies/ip-policy.md
+++ b/policies/ip-policy.md
@@ -54,7 +54,10 @@ CLAs can provide projects with more legal protection, while DCOs offer a simpler
 > [!TIP]
 > Joining CF doesn’t grant us any rights to your IP beyond what’s needed for project contributions. Your IP remains yours.
 
-Except for (a) each member’s commitment to be bound by this Policy, the applicable Project Code License(s), and the applicable Project Documentation License(s), in each case with respect to its or its employees’ authorized contributions to any Project; and (b) any applicable contributor license agreement, if any, no license is granted by the member to its intellectual property, and none shall be implied by general membership in the Commonhaus Foundation.
+General membership in the Commonhaus Foundation does not imply any license to a member's intellectual property.
+Members grant no license to their intellectual property to the Commonhaus Foundation, except under the following conditions:
+(a) their commitment to abide by this Policy, the applicable Project Code License(s), and the applicable Project Documentation License(s) for their contributions to any Project; and
+(b) any applicable contributor license agreement.
 
 ## Implementing the IP Policy
 


### PR DESCRIPTION
Revisions to IP Policy:

- Ensure statements regarding license usage are consistent
- Clarify requirements for contributions
- Require DCO, allow for CLA
- Clarify that non-commercial licenses *can* be used for documentation & samples

