### PR TITLE
Simplify conflict of interest policy

### DIFF
--- a/policies/conflict-of-interest.md
+++ b/policies/conflict-of-interest.md
@@ -11,23 +11,26 @@ This document outlines the Conflict of Interest Policy for the Commonhaus Founda
     - [Procedures for Determining Compensation](#procedures-for-determining-compensation)
 - [Disclosing Potential Conflicts of Interest](#disclosing-potential-conflicts-of-interest)
 - [Determining Whether a Conflict of Interest Exists](#determining-whether-a-conflict-of-interest-exists)
-    - [Review by the CFC](#review-by-the-cfc)
     - [Records of Review](#records-of-review)
-- [Violations](#violations)
 - [Review of Policy](#review-of-policy)
 
 ## Scope of Application
 
-This policy applies to all individuals within the CF who possess decision-making authority. This includes:
+This policy applies to all individuals within the CF who possess decision-making authority with respect to Foundation activities, assets, income, or expenses. This includes:
 
-- Members of the Commonhaus Foundation Council (CFC)
-- Members of the Extended Governance Committee (EGC)
+- Members of the [Commonhaus Foundation Council (CFC)][cfc]
+- Members of the [Extended Governance Committee (EGC)][egc]
 - Appointed officers of the CF
-- Project representatives
-- General members, when their personal or professional interests could potentially influence the decisions or activities of the Foundation.
 - Key employees[^1]
 
+[cfc]: ../bylaws/3-cf-council.md
+[egc]: ../bylaws/3-cf-council.md#extended-governance-committee-egc
+
 [^1]: If and when the CF employs full-time staff, a key employee is an employee who (a) has responsibilities or influence over the foundation similar to that of officers or Councilors; or (b) manages a program that represents 10% or more of the activities, assets, income, or expenses of the foundation; or (c) has or shares authority to control 10% or more of the foundation capital expenditures, operating budget, or compensation for employees.
+
+Relevant Florida Statute:
+
+- [617.0832](http://www.leg.state.fl.us/Statutes/index.cfm?App_mode=Display_Statute&Search_String=&URL=0600-0699/0617/Sections/0617.0832.html) Director conflicts of interest.
 
 ## Definitions
 
@@ -45,9 +48,7 @@ A **conflict of interest** arises when a covered individual’s personal interes
 
 ### Procedures for Determining Compensation
 
-When hiring staff or paying for contract work, the CFC will reference industry standards to ensure compensation is fair and justified. The process will be transparent and fully documented.
-
-All individuals will abstain from discussions or votes concerning their own compensation or that of those closely associated with them.
+When hiring staff, the CFC will reference industry standards to ensure compensation is not excessive. The process will be transparent and fully documented.
 
 ## Disclosing Potential Conflicts of Interest
 
@@ -57,32 +58,20 @@ It is important to note that the existence of a conflict does not mean the trans
 
 ## Determining Whether a Conflict of Interest Exists
 
-Upon the disclosure of a potential conflict, the CFC shall determine if a conflict of interest exists.
-
-The covered individual(s) and any other interested person(s) involved with the transaction shall not be present during the CFC's discussion or determination of whether a conflict of interest exists, except as provided in [below](#review-by-the-cfc).
-
-### Review by the CFC
-
-The CFC may ask questions of and receive presentation(s) from the covered individual(s) and any other interested person(s), but shall deliberate and vote on the transaction in their absence.
-
-The CFC shall ascertain that all material facts regarding the transaction and the covered individual’s conflict of interest have been disclosed to the CFC and shall compile appropriate data, such as comparability studies, to determine fair market value for the transaction.
-
-After exercising due diligence, which may include investigating alternatives that present no conflict, the CFC shall determine whether the transaction is in the Foundation’s best interest, for its own benefit, and whether it is fair and reasonable to the Foundation; the majority of disinterested members of the CFC then in office may approve the transaction.
+Upon the disclosure of a potential conflict, the CFC shall determine if a conflict of interest exists. The CFC may ask questions of and receive presentation(s) from the covered individual(s) and any other interested person(s), but shall deliberate and vote on the transaction in their absence.
 
 ### Records of Review
 
-The minutes of any meeting of the CFC pursuant to this policy shall contain the name of each covered individual who disclosed or was otherwise determined to have an interest in a transaction; the nature of the interest and whether it was determined to constitute a conflict of interest; any alternative transactions considered; the members of the CFC who were present during the deliberations on the transaction, those who voted on it, and to what extent interested persons were excluded from the deliberations; any comparability data or other information obtained and relied upon by the CFC and how the information was obtained; and the result of the vote, including, if applicable, the terms of the transaction that was approved and the date it was approved.
+The minutes of any CFC meeting that addresses conflict of interest disclosure or resolution will include:
+
+- The names of individuals with a potential conflict, the nature of their interest, and whether it was considered a conflict.
+- Details on alternative options reviewed, the CFC members who deliberated and voted, including how conflicts of interest were managed during these discussions.
+- The outcome of the vote, specifying the transaction's terms and approval date if relevant.
 
 #### Annual Disclosure and Compliance
 
-- CFC members (Councilors), EGC Members, and key employees (if any) must annually affirm that they have received, read, understood this policy, and that they agree to comply with it. They must disclose any financial interests and family relationships that could give rise to conflicts of interest.
+- CFC members (Councilors), EGC Members, and key employees (if any) must annually affirm that they have received, read, understood this policy, and that they agree to comply with it.
 - General CF members must affirm that they have received, read, understood this policy, and that they agree to comply with it, when applicable.
-
-## Violations
-
-If the CFC has reasonable cause to believe that a covered individual of the Foundation has failed to disclose actual or possible conflicts of interest, including those arising from a transaction with a related interested person, it shall inform such covered individual of the basis for this belief and afford the covered individual an opportunity to explain the alleged failure to disclose.
-
-If, after hearing the covered individual’s response and making further investigation as warranted by the circumstances, the CFC determines that the covered individual has failed to disclose an actual or possible conflict of interest, the CFC shall take appropriate disciplinary and corrective action.
 
 ## Review of Policy
 


### PR DESCRIPTION
- language for standard of compensation is "not excessive"
- add references to relevant Florida statute.
- Simplify determination of conflict and records, to avoid over-specification
- remove violation section, as already covered under bylaws (removing CFC/CF members.. )
