### PR TITLE
Clarify role/scope of CFC, EGC and EGC membership

### DIFF
--- a/bylaws/2-cf-membership.md
+++ b/bylaws/2-cf-membership.md
@@ -26,17 +26,20 @@ A **project** within the CF represents collaborative innovation in open-source t
 
 ## Project Representation
 
-**Diverse Voices, Unified Decision-Making:** Each project within the Commonhaus Foundation (CF) has its unique perspective. To ensure all projects have a say in the foundation's direction, each one appoints a representative to the [Extended Governance Committee (EGC)][egc]. These representatives are chosen according to the project's governance practices.
+**Diverse Voices, Unified Decision-Making:** Each project within the Commonhaus Foundation (CF) has its unique perspective. To ensure all projects have a say in the foundation's direction, each one appoints a representative to the [Extended Governance Committee (EGC)][egc]. These representatives are chosen according to the project's governance practices and do not have to be general members.
 
-**Dedicated Representation:** If an EGC representative is also elected to the [CF Council (CFC)][cfc], we recommend appointing an additional representative for the EGC. This helps maintain a focused approach to both specific project needs and the broader objectives of the CF.
+**Dedicated Representation:** If an EGC representative is elected to the [CF Council (CFC)][cfc], we recommend appointing an additional representative for the EGC to ensure project-specific needs are represented.
 
 ## General Members
 
 **Join as an individual.** Membership to the CF is open to all individuals who share our mission and meet the outlined eligibility criteria[^3].
 
-- **Eligibility Criteria**: Eligibility requires active and meaningful engagement with CF or its projects for at least three months. Meaningful contributions include commits and merged pull requests (code, documentation, or applications for demonstration, education, or advocacy), or triage, maintainer or moderator roles for CF project repositories.
-- **Application Process:** Submit an application to formalize membership (*details TBD*). The CFC reviews applications to ensure eligibility criteria are met.
-- **Transparent Review Process:** Applicants satisfying criteria are accepted. Declinations are clearly explained based on set criteria, with an appeal process available for further evaluation.
+- **Eligibility Criteria**: Eligibility requires active and meaningful engagement with CF or its projects for at least three months.
+    Meaningful contributions include commits and merged pull requests (code, documentation, or applications for demonstration, education, or advocacy); triage, maintainer or moderator roles for CF project repositories; or substantive participation in community forums.
+- **Application Process:** Submit an application to formalize membership (*details TBD*).
+    The CFC reviews applications to ensure eligibility criteria are met.
+- **Transparent Review Process:** Applicants satisfying criteria are accepted.
+    Declinations are clearly explained based on set criteria, with an appeal process available for further evaluation.
 
 [^3]: Companies (or similar legal entities) can ensure their views are represented by appointing a representative to the [advisory board][].
 
@@ -45,7 +48,8 @@ A **project** within the CF represents collaborative innovation in open-source t
 As a CF member, you're not just a part of our community; you shape its future. You're entitled to:
 
 - **Voice and Vote**: Contribute to discussions, sponsor issues, and vote in elections and referendums.
-- **Individual Representation:** Remember, your membership represents you, not your employer or any legal entity. Companies can engage through the [advisory board][].
+- **Individual Representation:** Remember, your membership represents you, not your employer or any legal entity.
+    Companies can engage through the [advisory board][].
 
 Relevant Florida Statute(s):
 
@@ -95,5 +99,6 @@ Relevant Florida Statute(s):
 [advisory board]: ./4-cf-advisory-board.md
 [cfc]: ./3-cf-council.md
 [egc]: ./3-cf-council.md#extended-governance-committee-egc
+[governance]: ./3-cf-council.md#voting
 [coc]: ../policies/code-of-conduct.md
 [coc-reports]: ../policies/code-of-conduct.md#handling-reports-and-escalations

--- a/bylaws/2-cf-membership.md
+++ b/bylaws/2-cf-membership.md
@@ -99,6 +99,5 @@ Relevant Florida Statute(s):
 [advisory board]: ./4-cf-advisory-board.md
 [cfc]: ./3-cf-council.md
 [egc]: ./3-cf-council.md#extended-governance-committee-egc
-[governance]: ./3-cf-council.md#voting
 [coc]: ../policies/code-of-conduct.md
 [coc-reports]: ../policies/code-of-conduct.md#handling-reports-and-escalations

--- a/bylaws/2-cf-membership.md
+++ b/bylaws/2-cf-membership.md
@@ -26,7 +26,7 @@ A **project** within the CF represents collaborative innovation in open-source t
 
 ## Project Representation
 
-**Diverse Voices, Unified Decision-Making:** Each project within the Commonhaus Foundation (CF) has its unique perspective. To ensure all projects have a say in the foundation's direction, each one appoints a representative to the [Extended Governance Committee (EGC)][egc]. These representatives are chosen according to the project's governance practices and do not have to be general members.
+**Diverse Voices, Unified Decision-Making:** Each project within the Commonhaus Foundation (CF) has its unique perspective, and its own legitimate interests in decisions taken by the foundation as a whole. To ensure that every project has a say in the direction of the foundation, each project appoints a representative to the [Extended Governance Committee (EGC)][egc]. The representative is chosen according to the project's own governance practices. The representative is not required to have or maintain general membership of the foundation.
 
 **Dedicated Representation:** If an EGC representative is elected to the [CF Council (CFC)][cfc], we recommend appointing an additional representative for the EGC to ensure project-specific needs are represented.
 

--- a/bylaws/3-cf-council.md
+++ b/bylaws/3-cf-council.md
@@ -4,7 +4,11 @@ weight: 3
 ---
 # Commonhaus Foundation Council and Offices
 
-The Commonhaus Foundation Council (CFC) serves as the Board of Directors for the Commonhaus Foundation (CF). Governed by the legal requirements of the State of Florida and as defined in our Articles of Incorporation and [Bylaws][bylaws], the CFC is responsible for the strategic, governance, and fiduciary aspects of the Foundation.
+The Commonhaus Foundation Council (CFC) serves as the Board of Directors for the Commonhaus Foundation (CF).
+It oversees the foundation's operations, ensuring compliance with legal requirements and the execution of strategic plans as defined in our Articles of Incorporation and [Bylaws][bylaws].
+This includes financial management, operational decisions, and adherence to state and federal regulations.
+
+While the [Extended Governance Committee (EGC)](#extended-governance-committee-egc) provides broad governance input, the CFC is specifically tasked with the practical application of these strategies, managing the foundation's daily administrative and legal tasks to support its goals and mission.
 
 - [Composition and Membership](#composition-and-membership)
     - [Tenure, Transition and Apportioning Duties](#tenure-transition-and-apportioning-duties)
@@ -15,7 +19,9 @@ The Commonhaus Foundation Council (CFC) serves as the Board of Directors for the
     - [Agendas, Access, and Records](#agendas-access-and-records)
     - [Quorum](#quorum)
 - [Electronic Participation and Decision-Making](#electronic-participation-and-decision-making)
-    - [Voting](#voting)
+- [Voting](#voting)
+    - [Matters approved by Supermajority Vote of the EGC](#matters-approved-by-supermajority-vote-of-the-egc)
+    - [Matters approved by Supermajority Vote of the CFC](#matters-approved-by-supermajority-vote-of-the-cfc)
 - [Committees and Delegation](#committees-and-delegation)
 
 ## Composition and Membership
@@ -144,9 +150,10 @@ Relevant Florida Statute(s):
 
 [^1]: As an example, a GitHub Discussion for on a specific topic would require a reaction  (per our [decision-making process][consensus]) from all Councilors to allow a decision to be made outside of a meeting. The final decisions and actions taken should be summarized in the Discussion.
 
-### Voting
+## Voting
 
-The CFC employs a consensus-driven approach for decision-making, detailed in [consensus guidelines][consensus]. When consensus cannot be reached, voting is utilized to resolve differences.
+The CFC employs a consensus-driven approach for decision-making, detailed in [consensus guidelines][consensus].
+When consensus cannot be reached, voting is utilized to resolve differences.
 
 - **Majority Voting**: Most decisions are subject to a simple majority vote of Councilors present and voting at a meeting or acting [through written consent](#electronic-participation-and-decision-making).
 
@@ -154,23 +161,24 @@ The CFC employs a consensus-driven approach for decision-making, detailed in [co
     - Approval by at least two-thirds of the total voting members of the CFC or the EGC at a meeting with at least two-thirds of voting members present.
     - Approval by two-thirds of all voting members acting [through written consent](#electronic-participation-and-decision-making).
 
-*Definition of Voting Members*:
+**Definition of Voting Members**:
 
 - For the CFC: All current voting Councilors.
 - For the EGC: All voting Councilors and project representatives.
 
-#### Matters approved by Supermajority Vote of the EGC and CFC
+### Matters approved by Supermajority Vote of the EGC
 
 - Amending the Articles of Incorporation or the Bylaws.
 - Changing the size of the CFC.
 - Modifying the rights of membership.
-- Approving a proposed merger or dissolution.
+- Final approval of a proposed merger or dissolution.
+- Suspending or revoking a project's membership.
 
-#### Matters approved by Supermajority Vote of the CFC
+### Matters approved by Supermajority Vote of the CFC
 
 - Suspending or revoking an individual's membership.
 - Hiring or terminating the Executive Director.
-- Approving a proposed merger or dissolution.
+- Draft proposal for merger or dissolution.
 
 Relevant Florida Statute(s):
 


### PR DESCRIPTION
- Clarify that a Project Representative appointed to the EGC does not have to be a CF Member
- Clarify role of the CFC (as working board for foundation operations)
- Clarify terms in distinction of votes requiring EGC approval and those requiring CFC approval
